### PR TITLE
Date and Timestamp timeZone probleme.

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -577,13 +577,13 @@ Local<Date> OracleDateToV8Date(oracle::occi::Date* d) {
   unsigned int month, day, hour, min, sec;
   d->getDate(year, month, day, hour, min, sec);
   Local<Date> date = uni::DateCast(Date::New(0.0));
-  CallDateMethod(date, "setUTCMilliseconds", 0);
-  CallDateMethod(date, "setUTCSeconds", sec);
-  CallDateMethod(date, "setUTCMinutes", min);
-  CallDateMethod(date, "setUTCHours", hour);
-  CallDateMethod(date, "setUTCDate", day);
-  CallDateMethod(date, "setUTCMonth", month - 1);
-  CallDateMethod(date, "setUTCFullYear", year);
+  CallDateMethod(date, "setMilliseconds", 0);
+  CallDateMethod(date, "setSeconds", sec);
+  CallDateMethod(date, "setMinutes", min);
+  CallDateMethod(date, "setHours", hour);
+  CallDateMethod(date, "setDate", day);
+  CallDateMethod(date, "setMonth", month - 1);
+  CallDateMethod(date, "setFullYear", year);
   return date;
 }
 
@@ -596,13 +596,13 @@ Local<Date> OracleTimestampToV8Date(oracle::occi::Timestamp* d) {
   ms = (fs / 1000000.0) + 0.5; // add 0.5 to round to nearest millisecond
 
   Local<Date> date = uni::DateCast(Date::New(0.0));
-  CallDateMethod(date, "setUTCMilliseconds", ms);
-  CallDateMethod(date, "setUTCSeconds", sec);
-  CallDateMethod(date, "setUTCMinutes", min);
-  CallDateMethod(date, "setUTCHours", hour);
-  CallDateMethod(date, "setUTCDate", day);
-  CallDateMethod(date, "setUTCMonth", month - 1);
-  CallDateMethod(date, "setUTCFullYear", year);
+  CallDateMethod(date, "setMilliseconds", ms);
+  CallDateMethod(date, "setSeconds", sec);
+  CallDateMethod(date, "setMinutes", min);
+  CallDateMethod(date, "setHours", hour);
+  CallDateMethod(date, "setDate", day);
+  CallDateMethod(date, "setMonth", month - 1);
+  CallDateMethod(date, "setFullYear", year);
   return date;
 }
 


### PR DESCRIPTION
When inserting a JavaScript date into a timestamp or date column, Ex : 
Wed May 06 2015 15:26:11 GMT+0100 (CET), the value retrieved from a select query, has an hour added to the original date, as you can see, the hour is added to match the time Zone utc+1 in this case.
calling setHours, setMinutes ... instead of setUTCHours, setUTCMinutes solved this.
